### PR TITLE
ci: migrate npm publish to OIDC (Trusted Publishing)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write  # GitHub Release作成に必要
-      id-token: write # npm provenance に必要
+      id-token: write  # npm OIDC (Trusted Publishing) に必要
     steps:
       - uses: actions/checkout@v4
 
@@ -78,19 +78,13 @@ jobs:
             echo "SKIP_PUBLISH=false" >> $GITHUB_ENV
           fi
 
-      - name: Publish to npm
+      - name: Publish to npm (OIDC)
         if: env.SKIP_PUBLISH == 'false'
         run: pnpm publish --provenance --access public --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub Release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
           body: |
             Changes in this Release
             - Check the [CHANGELOG](https://github.com/TAKEDA-Takashi/jt-cli/blob/main/CHANGELOG.md) for details

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write  # GitHub Release作成に必要
-      id-token: write  # npm OIDC (Trusted Publishing) に必要
+      id-token: write # npm provenance に必要
     steps:
       - uses: actions/checkout@v4
 
@@ -78,13 +78,19 @@ jobs:
             echo "SKIP_PUBLISH=false" >> $GITHUB_ENV
           fi
 
-      - name: Publish to npm (OIDC)
+      - name: Publish to npm
         if: env.SKIP_PUBLISH == 'false'
         run: pnpm publish --provenance --access public --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
           body: |
             Changes in this Release
             - Check the [CHANGELOG](https://github.com/TAKEDA-Takashi/jt-cli/blob/main/CHANGELOG.md) for details


### PR DESCRIPTION
## Summary

npm公開をOIDC（Trusted Publishing）ベースの認証に移行します。

## Changes

- `NODE_AUTH_TOKEN` を削除し、OIDC認証を使用
- 非推奨の `actions/create-release@v1` を `softprops/action-gh-release@v2` に更新

## Benefits

- **セキュリティ向上**: 長期間有効なトークンを保存する必要がなくなる
- **メンテナンス削減**: トークンの期限切れを気にする必要がなくなる
- **監査性向上**: 公開元のリポジトリ・ワークフローが検証可能

## Prerequisites

npm側でTrusted Publishingの設定が完了していること:
- Repository owner: `TAKEDA-Takashi`
- Repository name: `jt-cli`
- Workflow filename: `release.yml`

## Test plan

- [ ] マージ後、v1.2.4タグを再作成してリリースワークフローが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)