### PR TITLE
chore: リリースワークフローの整備

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,8 +214,8 @@ echo '{}' | jt '$undefined('
 
 ### Prerequisites
 
-- Node.js 20 or higher (Node.js 24 recommended)
-- npm or yarn
+- Node.js 22 or higher (Node.js 24 recommended)
+- pnpm
 - nvm (recommended for managing Node.js versions)
 
 ### Setup
@@ -229,13 +229,13 @@ cd jt-cli
 nvm use  # This will use the version specified in .nvmrc (Node.js 24)
 
 # Install dependencies
-npm install
+pnpm install
 
 # Run tests
-npm test
+pnpm test
 
 # Build
-npm run build
+pnpm run build
 ```
 
 ### Testing
@@ -244,13 +244,13 @@ This project follows Test-Driven Development (TDD) practices:
 
 ```bash
 # Run all tests
-npm test
+pnpm test
 
 # Run tests in watch mode
-npm run test:watch
+pnpm run test:watch
 
 # Run with coverage
-npm run test:coverage
+pnpm run test:coverage
 ```
 
 ## Contributing

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,136 +4,68 @@
 
 ## 前提条件
 
-1. NPMアカウントを持っていること
-2. GitHub Secretsに `NPM_TOKEN` が設定されていること
+1. NPMアカウントを持っていること（OIDC Trusted Publishing設定済み）
+2. GitHub CLIがインストール・認証済みであること（`gh auth status`）
 3. mainブランチが最新の状態であること
-
-## リリース前チェックリスト
-
-リリース前に以下の項目を必ず確認してください：
-
-- [ ] すべてのテストがパス（`npm test`）
-- [ ] Biomeリントチェックがパス（`npm run lint:check`）  
-- [ ] TypeScriptチェックがパス（`npm run typecheck`）
-- [ ] ビルドが成功（`npm run build`）
-- [ ] CHANGELOG.mdのUnreleasedセクションが更新済み
-- [ ] 新機能のドキュメント（README.md）が更新済み
-- [ ] 破壊的変更がある場合、移行ガイドを記載
 
 ## リリース手順
 
-### 1. 変更内容の確認
+### 1. リリーススクリプトの実行
+
+mainブランチから以下を実行します:
 
 ```bash
-# mainブランチを最新に
-git checkout main
-git pull origin main
-
-# テストがすべてパスすることを確認
-npm test
-npm run lint:check
-npm run typecheck
+pnpm run release <patch|minor|major>
 ```
 
-### 2. CHANGELOG.mdの更新
+スクリプトが自動的に以下を行います:
+1. 前提条件チェック（mainブランチ、クリーンな状態、リモートと同期）
+2. リリース前チェック（test, check, typecheck, build）
+3. バージョン更新（package.json, pnpm-lock.yaml）
+4. CHANGELOG.mdの`[Unreleased]`セクションにバージョンと日付を設定
+5. リリースブランチ作成（`release/vX.Y.Z`）+ コミット + プッシュ
+6. GitHub PR作成
 
-リリース前に必ずCHANGELOG.mdを更新します：
+### 2. リリースPRの編集
+
+PRが作成されたら、以下を行います:
+
+- **CHANGELOG.md**: `[Unreleased]`セクションにリリースノートを記載
+  - Added / Changed / Fixed / Removed / Security などのカテゴリを使用
+- **README.md**: 新機能のドキュメントを追加（必要に応じて）
+- **破壊的変更がある場合**: 移行ガイドを記載
+
+### 3. PRのレビューとマージ
+
+PRをレビューし、mainにマージします。
+
+### 4. タグの作成とプッシュ
+
+マージ後、以下を実行してリリースをトリガーします:
 
 ```bash
-# 最後のリリース以降のコミットを確認
-git log v$(node -p "require('./package.json').version")..HEAD --oneline
-
-# CHANGELOG.mdのUnreleasedセクションに変更内容を記載
-# 形式: Added/Changed/Fixed/Removed/Security
+git switch main && git pull
+git tag vX.Y.Z
+git push origin vX.Y.Z
 ```
 
-### 3. バージョンの更新
-
-```bash
-# パッチリリース (0.1.0 → 0.1.1)
-npm version patch
-
-# マイナーリリース (0.1.0 → 0.2.0)
-npm version minor
-
-# メジャーリリース (0.1.0 → 1.0.0)
-npm version major
-```
-
-このコマンドは以下を自動的に行います：
-- package.json のバージョンを更新
-- Git コミットを作成
-- バージョンタグを作成（例: v0.1.1）
-
-### 4. 変更をプッシュ
-
-```bash
-# コミットとタグをプッシュ
-git push origin main
-git push origin --tags
-```
-
-### 5. 自動リリースの確認
-
-タグのプッシュにより、GitHub Actionsが自動的に：
+タグのプッシュにより、GitHub Actionsが自動的に:
 1. すべてのテストを実行
 2. ビルドを実行
-3. NPMにパッケージを公開
+3. NPMにパッケージを公開（OIDC認証）
 4. GitHub Releaseを作成
 
 進行状況は [Actions タブ](https://github.com/TAKEDA-Takashi/jt-cli/actions) で確認できます。
 
-## トラブルシューティング
-
-### NPM_TOKEN エラー
-
-エラー: `npm ERR! code E401`
-
-解決方法：
-1. NPMトークンが有効であることを確認
-2. GitHub Secrets の `NPM_TOKEN` を更新
-
-### バージョン不一致エラー
-
-エラー: `Tag version does not match package.json version`
-
-解決方法：
-1. package.json のバージョンを手動で修正
-2. `git add package.json && git commit -m "fix: version"`
-3. 正しいバージョンでタグを作り直す
-
-## 初回公開時の注意
-
-初回公開前に以下を確認：
-
-1. パッケージ名が利用可能か確認
-   ```bash
-   npm view @2017takeda/jt-cli
-   ```
-
-2. ローカルでの公開テスト（dry-run）
-   ```bash
-   npm publish --dry-run
-   ```
-
-3. package.json の設定確認
-   - `name`: @2017takeda/jt-cli
-   - `publishConfig.access`: "public"
-   - `files`: 公開するファイルが正しく指定されているか
-
 ## セマンティックバージョニング
-
-バージョン番号の付け方：
 
 - **PATCH (x.x.1)**: バグ修正、後方互換性のある修正
 - **MINOR (x.1.0)**: 新機能追加、後方互換性あり
 - **MAJOR (1.0.0)**: 破壊的変更、後方互換性なし
 
-## リリースノート作成ガイドライン
+## CHANGELOGのカテゴリ
 
-### CHANGELOGのカテゴリ
-
-Keep a Changelogの形式に従い、以下のカテゴリを使用：
+[Keep a Changelog](https://keepachangelog.com/) の形式に従います:
 
 - **Added**: 新機能
 - **Changed**: 既存機能の変更
@@ -141,33 +73,28 @@ Keep a Changelogの形式に従い、以下のカテゴリを使用：
 - **Removed**: 削除された機能
 - **Fixed**: バグ修正
 - **Security**: セキュリティ関連の修正
+- **Updated**: 依存関係の更新
 
-### 良い変更記述の例
+## トラブルシューティング
 
-```markdown
-### Added
-- CSV input format support with automatic header detection
-- Raw string output option (-r/--raw-string) for unquoted string results
+### NPM公開エラー
 
-### Fixed
-- Enhanced compact JSON colorization to handle escaped strings correctly
-```
+エラー: `npm ERR! code E401`
 
-### リリースノートに含めるべき情報
+解決方法:
+1. npm OIDC (Trusted Publishing) の設定を確認
+2. GitHub Actionsの`id-token: write`パーミッションを確認
 
-- 新機能（使用例を含む）
-- バグ修正（影響範囲を明記）
-- 破壊的変更（移行ガイド必須）
-- パフォーマンス改善
-- 既知の問題
-- 貢献者への謝辞
+### バージョン不一致エラー
 
-### コミットメッセージからの自動生成
+エラー: `Tag version does not match package.json version`
+
+解決方法:
+1. package.jsonのバージョンとタグが一致していることを確認
+2. 不一致の場合、タグを削除して正しいバージョンで再作成
+
+### ローカルでの公開テスト（dry-run）
 
 ```bash
-# feat: で始まるコミットを抽出（新機能）
-git log v1.1.0..HEAD --oneline | grep -E "^[a-f0-9]+ feat"
-
-# fix: で始まるコミットを抽出（バグ修正）
-git log v1.1.0..HEAD --oneline | grep -E "^[a-f0-9]+ fix"
+pnpm publish --dry-run
 ```

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "release": "./scripts/release.sh"
   },
   "dependencies": {
     "chalk": "^5.6.2",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# リリース準備スクリプト
+# Usage: ./scripts/release.sh <patch|minor|major>
+#
+# 1. リリース前チェック（test, check, typecheck, build）
+# 2. バージョン更新（package.json）
+# 3. CHANGELOG.md の [Unreleased] セクションにバージョンとリリース日を設定
+# 4. リリースブランチ作成 + コミット
+# 5. GitHub PR作成
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$PROJECT_DIR"
+
+# --- 引数チェック ---
+BUMP_TYPE="${1:-}"
+if [[ ! "$BUMP_TYPE" =~ ^(patch|minor|major)$ ]]; then
+  echo "Usage: $0 <patch|minor|major>"
+  echo ""
+  echo "Examples:"
+  echo "  $0 patch   # 1.2.4 -> 1.2.5"
+  echo "  $0 minor   # 1.2.4 -> 1.3.0"
+  echo "  $0 major   # 1.2.4 -> 2.0.0"
+  exit 1
+fi
+
+# --- 前提条件チェック ---
+# mainブランチにいることを確認
+CURRENT_BRANCH=$(git branch --show-current)
+if [[ "$CURRENT_BRANCH" != "main" ]]; then
+  echo "Error: mainブランチから実行してください（現在: $CURRENT_BRANCH）"
+  exit 1
+fi
+
+# ワーキングツリーがクリーンであることを確認
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "Error: コミットされていない変更があります。先にコミットまたはstashしてください。"
+  exit 1
+fi
+
+# mainが最新であることを確認
+git fetch origin main --quiet
+LOCAL_HASH=$(git rev-parse HEAD)
+REMOTE_HASH=$(git rev-parse origin/main)
+if [[ "$LOCAL_HASH" != "$REMOTE_HASH" ]]; then
+  echo "Error: ローカルのmainがリモートと一致しません。git pullしてください。"
+  exit 1
+fi
+
+# --- バージョン計算 ---
+CURRENT_VERSION=$(node -p "require('./package.json').version")
+IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
+
+case "$BUMP_TYPE" in
+  patch) PATCH=$((PATCH + 1)) ;;
+  minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+  major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+esac
+
+NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+RELEASE_DATE=$(date +%Y-%m-%d)
+BRANCH_NAME="release/v${NEW_VERSION}"
+
+echo "=== Release Preparation ==="
+echo "  Current version: ${CURRENT_VERSION}"
+echo "  New version:     ${NEW_VERSION} (${BUMP_TYPE})"
+echo "  Release date:    ${RELEASE_DATE}"
+echo "  Branch:          ${BRANCH_NAME}"
+echo ""
+
+# --- 確認 ---
+read -r -p "続行しますか？ (y/N): " CONFIRM
+if [[ "$CONFIRM" != "y" && "$CONFIRM" != "Y" ]]; then
+  echo "キャンセルしました。"
+  exit 0
+fi
+
+# --- リリース前チェック ---
+echo ""
+echo "--- Running pre-release checks ---"
+
+echo "[1/4] pnpm run check..."
+pnpm run check
+
+echo "[2/4] pnpm run typecheck..."
+pnpm run typecheck
+
+echo "[3/4] pnpm test..."
+pnpm test -- --run
+
+echo "[4/4] pnpm run build..."
+pnpm run build
+
+echo "--- All checks passed ---"
+echo ""
+
+# --- リリースブランチ作成 ---
+echo "Creating branch: ${BRANCH_NAME}"
+git switch -c "$BRANCH_NAME"
+
+# --- package.json のバージョン更新 ---
+echo "Updating package.json version to ${NEW_VERSION}"
+# node で直接書き換え（JSONフォーマットを維持）
+node -e "
+const fs = require('fs');
+const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+pkg.version = '${NEW_VERSION}';
+fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+"
+
+# --- CHANGELOG.md の更新 ---
+echo "Updating CHANGELOG.md"
+# [Unreleased] を [NEW_VERSION] - DATE に変更し、新しい [Unreleased] セクションを追加
+sed -i '' "s/## \[Unreleased\]/## [Unreleased]\n\n## [${NEW_VERSION}] - ${RELEASE_DATE}/" CHANGELOG.md
+
+# フッターのリンクを更新
+sed -i '' "s|\[Unreleased\]: \(.*\)/compare/v${CURRENT_VERSION}\.\.\.HEAD|[Unreleased]: \1/compare/v${NEW_VERSION}...HEAD\n[${NEW_VERSION}]: \1/compare/v${CURRENT_VERSION}...v${NEW_VERSION}|" CHANGELOG.md
+
+# --- pnpm-lock.yaml の更新 ---
+echo "Updating pnpm-lock.yaml"
+pnpm install --lockfile-only
+
+# --- コミット ---
+echo "Creating release commit"
+git add package.json CHANGELOG.md pnpm-lock.yaml
+git commit -m "chore: release v${NEW_VERSION}"
+
+# --- プッシュ & PR作成 ---
+echo "Pushing branch and creating PR"
+git push -u origin "$BRANCH_NAME"
+
+PR_URL=$(gh pr create \
+  --title "chore: release v${NEW_VERSION}" \
+  --body "$(cat <<PREOF
+## Release v${NEW_VERSION}
+
+### Checklist
+- [x] All tests pass (\`pnpm test\`)
+- [x] Biome check passes (\`pnpm run check\`)
+- [x] TypeScript check passes (\`pnpm run typecheck\`)
+- [x] Build succeeds (\`pnpm run build\`)
+- [ ] CHANGELOG.md \`[Unreleased]\` section has release notes
+- [ ] README.md is up to date
+
+### After Merge
+PR マージ後、以下を実行してリリースをトリガーしてください:
+
+\`\`\`bash
+git switch main && git pull
+git tag v${NEW_VERSION}
+git push origin v${NEW_VERSION}
+\`\`\`
+PREOF
+)")
+
+echo ""
+echo "=== Release PR created ==="
+echo "  PR: ${PR_URL}"
+echo ""
+echo "次のステップ:"
+echo "  1. CHANGELOG.md の [Unreleased] セクションにリリースノートを記載"
+echo "  2. README.md に新機能のドキュメントを追加（必要に応じて）"
+echo "  3. PR をレビュー・マージ"
+echo "  4. マージ後にタグを打ってpush:"
+echo "     git switch main && git pull"
+echo "     git tag v${NEW_VERSION}"
+echo "     git push origin v${NEW_VERSION}"


### PR DESCRIPTION
## Summary

- リリース準備スクリプト (`scripts/release.sh`) を追加
- PR ベースのリリースフローに移行
- README.md の開発環境情報を更新（Node.js 22+, pnpm）

## Changes

### `scripts/release.sh`
リリース準備を自動化するスクリプト。`pnpm run release <patch|minor|major>` で実行:
1. 前提条件チェック（mainブランチ、クリーン、リモート同期）
2. リリース前チェック（test, check, typecheck, build）
3. バージョン更新（package.json, pnpm-lock.yaml）
4. CHANGELOG.md 更新（`[Unreleased]` → `[vX.Y.Z] - YYYY-MM-DD`）
5. リリースブランチ作成 + コミット + プッシュ + PR作成

### `RELEASE.md`
新しいPRベースのリリースフローに合わせて全面改訂

### `README.md`
- Node.js 20 → 22 に更新
- npm → pnpm に更新

## Test plan

- [x] `pnpm test` 全テスト通過
- [x] `pnpm run check` Biomeチェック通過
- [x] `pnpm run typecheck` 型チェック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)