### PR TITLE
chore: release v1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.1] - 2026-03-30
+
+### Changed
+- Migrated package manager from pnpm back to npm
+- CI workflows now use `npm install` for cross-version npm compatibility
+
+### Updated
+- @biomejs/biome: 2.4.5 → 2.4.9
+
+### Added
+- Claude Code pre-commit quality check hook (`.claude/settings.json`)
+
 ## [1.3.0] - 2026-03-07
 
 ### Added
@@ -130,7 +142,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - All dependencies are up to date
 - No known vulnerabilities
 
-[Unreleased]: https://github.com/TAKEDA-Takashi/jt-cli/compare/v1.3.0...HEAD
+[Unreleased]: https://github.com/TAKEDA-Takashi/jt-cli/compare/v1.3.1...HEAD
+[1.3.1]: https://github.com/TAKEDA-Takashi/jt-cli/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/TAKEDA-Takashi/jt-cli/compare/v1.2.4...v1.3.0
 [1.2.4]: https://github.com/TAKEDA-Takashi/jt-cli/compare/v1.2.3...v1.2.4
 [1.2.3]: https://github.com/TAKEDA-Takashi/jt-cli/compare/v1.2.0...v1.2.3

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@2017takeda/jt-cli",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@2017takeda/jt-cli",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@2017takeda/jt-cli",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "JSONata query and transformation tool for the command line",
   "keywords": [
     "jsonata",


### PR DESCRIPTION
## Release v1.3.1

### Checklist
- [x] All tests pass (`npm test`)
- [x] Biome check passes (`npm run check`)
- [x] TypeScript check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] CHANGELOG.md updated with release notes
- [x] README.md is up to date

### After Merge
PR マージ後、以下を実行してリリースをトリガーしてください:

```bash
git switch main && git pull
git tag v1.3.1
git push origin v1.3.1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)